### PR TITLE
added to the margin left to the class

### DIFF
--- a/src/components/UserData/UserTag.jsx
+++ b/src/components/UserData/UserTag.jsx
@@ -13,7 +13,7 @@ function UserTag(props){
          <a href="#" >
          <img className="w-[50px] h-[50px] rounded-full" src={props.imageLink} />
             </a> 
-            <span className="mt-2.5 ml-2">Purna lakshitha</span>
+            <span className="mt-2.5 ml-2 mr-1.5">Purna lakshitha</span>
         </div>
 
         


### PR DESCRIPTION
This pull request includes a small change to the `UserTag` component in the `src/components/UserData/UserTag.jsx` file. The change adds a right margin to the `span` element displaying the user's name.

* [`src/components/UserData/UserTag.jsx`](diffhunk://#diff-584d61ab8bd0803e64e9e4bd01cae65173cc809ecdcf26f36421175689016426L16-R16): Added `mr-1.5` class to the `span` element to add a right margin.